### PR TITLE
Remove video clip after frame extraction

### DIFF
--- a/mqtt_client.py
+++ b/mqtt_client.py
@@ -181,7 +181,9 @@ def download_video_clip_and_extract_frames(event_id, gap_secs):
         logging.info(f"Video clip for event {event_id} saved as {clip_filename}.")
 
         # After downloading, extract frames
-        return extract_frames(clip_filename, gap_secs)
+        frames = extract_frames(clip_filename, gap_secs)
+        os.remove(clip_filename)
+        return frames
     else:
         logging.error(
             f"Failed to retrieve video clip for event {event_id}. Status code: {response.status_code}"


### PR DESCRIPTION
Modified the download_video_clip_and_extract_frames function in mqtt_client.py to delete the downloaded video clip after the frames have been extracted. This change helps to manage disk space by removing unnecessary files after they have been processed.