### PR TITLE
Use openai-compatible endpoints 

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -7,6 +7,20 @@ mqtt_username: YOUR_MQTT_USER # optional
 mqtt_password: YOUR_MQTT_PASSWORD # optional
 verbose_summary_mode: false #optional, default true
 
+###############################################################################
+# openai endpoint stuff.  if you have a local llm serving openai compatible
+# endpoints (like ollama or vllm or lm-studio), change these to hit your
+# local install.  e.g. if http://ollama.local:11434/v1 is the openai 
+# compatible endpoint you would change the below variables the following:
+# openai_api_host: localhost
+# openai_api_port: 11434
+# openai_api_protocol: http
+###############################################################################
+
+openai_api_host: api.openai.com # optional, default api.openai.com
+openai_api_port: 443 # optional, default 443
+openai_api_protocol: https # optional, default https
+
 #more optional configs are below
 model: gpt-4o #optional
 

--- a/mqtt_client.py
+++ b/mqtt_client.py
@@ -45,6 +45,12 @@ FRIGATE_SERVER_PORT = config.get("frigate_server_port", 5000)
 THUMBNAIL_ENDPOINT = "/api/events/{}/thumbnail.jpg"
 CLIP_ENDPOINT = "/api/events/{}/clip.mp4"
 
+
+#openai
+OPENAI_API_HOST = config.get("openai_api_host", "api.openai.com")
+OPENAI_API_PORT = config.get("openai_api_port", 443)
+OPENAI_API_PROTOCOL = config.get("openai_api_protocol", "https")
+
 # Video frame sampling settings
 GAP_SECS = 3
 
@@ -165,7 +171,7 @@ def prompt_gpt4_with_video_frames(prompt, base64_frames, low_detail=True):
     }
 
     return requests.post(
-        "https://api.openai.com/v1/chat/completions", headers=headers, json=payload
+        f"{OPENAI_API_PROTOCOL}://{OPENAI_API_HOST}:{OPENAI_API_PORT}/v1/chat/completions", headers=headers, json=payload
     )
 
 


### PR DESCRIPTION
This updates the mqtt_client and config example to allow for user-defined openai api compatible endpoints.  Users are then able to use local models rather than chatgpt